### PR TITLE
Multiple Elevators - Elevators Subsystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 make: build
 
 build:
+	mkdir -p build
 	javac -cp src/:vendor/junit-4.10.jar src/**/*.java -d build/
 
 run: build
@@ -13,7 +14,7 @@ clean:
 	rm -r build/**/*.class
 
 elevator: build
-	java -cp build/ elevator.ElevatorSubSystem
+	java -cp build/ elevator.ElevatorManager
 
 scheduler: build
 	java -cp build/ scheduler.Scheduler

--- a/run
+++ b/run
@@ -4,6 +4,6 @@ trap 'kill $(jobs -p)' EXIT
 
 cd build || return
 
-java elevator.ElevatorSubSystem &
+java elevator.ElevatorManager &
 java scheduler.Scheduler &
 java floor.FloorManager

--- a/src/elevator/Elevator.java
+++ b/src/elevator/Elevator.java
@@ -11,6 +11,7 @@ import messages.*;
  */
 public class Elevator {
 
+	// State is the possible states that the elevator can be in.
 	public enum State {
 		MOVING_UP, MOVING_DOWN, STOPPED_DOORS_CLOSED, STOPPED_DOORS_OPENED
 	}
@@ -45,6 +46,10 @@ public class Elevator {
 
 	public State getState() {
 		return state;
+	}
+
+	public boolean isMoving() {
+		return state == State.MOVING_UP || state == State.MOVING_DOWN;
 	}
 
 	/*

--- a/src/elevator/ElevatorManager.java
+++ b/src/elevator/ElevatorManager.java
@@ -1,0 +1,36 @@
+package elevator;
+
+import floor.SimulationVars;
+
+public class ElevatorManager {
+
+    private ElevatorSubSystem[] elevatorSubSystems;
+
+    ElevatorManager(int numberOfElevators) {
+        elevatorSubSystems = new ElevatorSubSystem[numberOfElevators];
+        for (int i = 0; i < elevatorSubSystems.length; i ++) {
+            elevatorSubSystems[i] = new ElevatorSubSystem(i);
+        }
+    }
+
+    public ElevatorSubSystem[] getElevatorSubsystems() {
+        return elevatorSubSystems;
+    }
+
+    public void run() {
+        Thread[] elevatorThreads = new Thread[elevatorSubSystems.length];
+        for (int i = 0; i < elevatorSubSystems.length; i ++) {
+            Thread t = new Thread(elevatorSubSystems[i]);
+            t.start();
+            elevatorThreads[i] = t;
+        }
+        for (Thread t : elevatorThreads) {
+            try { t.join(); } catch (InterruptedException e) { }
+        }
+    }
+
+    public static void main(String args[]) {
+        ElevatorManager em = new ElevatorManager(SimulationVars.numberOfElevators);
+        em.run();
+    }
+}

--- a/src/floor/SimulationVars.java
+++ b/src/floor/SimulationVars.java
@@ -3,13 +3,13 @@ package floor;
 import java.net.InetAddress;
 
 public  class SimulationVars {
-	public static int numberOfElevators = 1;
+	public static int numberOfElevators = 3;
 	public static int numberOfFloors = 3;
 
 	public static int elevatorTravelTime = 500;
 
-	public static InetAddress[] elevatorAddresses = {InetAddress.getLoopbackAddress()};
-	public static int[] elevatorPorts = {4000};
+	public static InetAddress[] elevatorAddresses = {InetAddress.getLoopbackAddress(), InetAddress.getLoopbackAddress(), InetAddress.getLoopbackAddress()};
+	public static int[] elevatorPorts = {4000, 4001, 4002};
 
 	public static InetAddress schedulerAddress = InetAddress.getLoopbackAddress();
 	public static int schedulerPort = 3000;

--- a/src/scheduler/Scheduler.java
+++ b/src/scheduler/Scheduler.java
@@ -14,6 +14,7 @@ import messages.ElevatorRequestMessage;
 import messages.FloorArrivalMessage;
 import messages.FloorRequestMessage;
 import messages.Message;
+import floor.SimulationVars;
 
 public class Scheduler {
 	public static String HOST = "127.0.0.1";
@@ -101,15 +102,11 @@ public class Scheduler {
 
 	private void sendToElevator(MessageType action) {
 		System.out.println("Scheduler: Sending message of type " + action);
+		// TODO set the correct target elevator in the message
+		int targetElevator = 0;
 		byte[] data = Message.serialize((new ElevatorMessage(action)));
-		InetAddress destHost = null;
-		try {
-			destHost = InetAddress.getByName(ElevatorSubSystem.HOST);
-		} catch (UnknownHostException e) {
-			e.printStackTrace();
-			System.exit(1);
-		}
-		DatagramPacket pack = new DatagramPacket(data, data.length, destHost, ElevatorSubSystem.PORT);
+		DatagramPacket pack = new DatagramPacket(data, data.length,
+				SimulationVars.elevatorAddresses[targetElevator], SimulationVars.elevatorPorts[targetElevator]);
 		Message.send(sendSock, pack);
 	}
 


### PR DESCRIPTION
This PR adds support for multiple elevators. Since we are only running one machine per subsystem we don't need to design the elevator subsystem to act as separate units. Therefore only 1 set of sockets are needed and the subsystem can decide which elevator needs to handle the message based on the elevator `id` provided in each message.