### PR TITLE
Multithread scheduler

### DIFF
--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -3,6 +3,7 @@ package scheduler;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
+import java.util.concurrent.*;
 
 import elevator.Elevator;
 import elevator.ElevatorQueue;
@@ -19,6 +20,7 @@ public class SchedulerSubSystem {
 	private Scheduler scheduler;
 	private SchedulerMessenger messenger;
 	private Thread faultDetectorThread;
+	private ExecutorService threadPool = Executors.newFixedThreadPool(3);
 
 	public SchedulerSubSystem() {
 		messenger = new SchedulerMessenger();
@@ -33,12 +35,28 @@ public class SchedulerSubSystem {
 
 		Message m = messenger.receive();
 
+
 		if (m instanceof ElevatorRequestMessage) {
-			handleElevatorRequest((ElevatorRequestMessage) m);
+			threadPool.execute(new Runnable() {
+				@Override
+				public void run() {
+					handleElevatorRequest((ElevatorRequestMessage) m);
+				}
+			});
 		} else if (m instanceof FloorArrivalMessage) {
-			handleFloorArrival((FloorArrivalMessage) m);
+			threadPool.execute(new Runnable() {
+				@Override
+				public void run() {
+					handleFloorArrival((FloorArrivalMessage) m);
+				}
+			});
 		} else if (m instanceof FloorRequestMessage) {
-			handleFloorRequest((FloorRequestMessage) m);
+			threadPool.execute(new Runnable() {
+				@Override
+				public void run() {
+					handleFloorRequest((FloorRequestMessage) m);
+				}
+			});
 		}
 	}
 
@@ -85,8 +103,8 @@ public class SchedulerSubSystem {
 	}
 
 	public static void main(String args[]) {
-			System.out.println("Scheduler: Starting on port 3000");
-			SchedulerSubSystem s = new SchedulerSubSystem();
-			s.run();
-		}
+		System.out.println("Scheduler: Starting on port 3000");
+		SchedulerSubSystem s = new SchedulerSubSystem();
+		s.run();
 	}
+}

--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -21,7 +21,7 @@ public class SchedulerSubSystem {
 	private Scheduler scheduler;
 	private SchedulerMessenger messenger;
 	private Thread faultDetectorThread;
-	private ExecutorService threadPool = Executors.newFixedThreadPool(3);
+	private ExecutorService threadPool;
 	private ArrayList<Long> ElevatorRequestTimes;
 	private ArrayList<Long> FloorArrivalTimes;
 	private ArrayList<Long> FloorRequestTimes;
@@ -30,6 +30,7 @@ public class SchedulerSubSystem {
 		ElevatorRequestTimes = new ArrayList<Long>();
 		FloorArrivalTimes = new ArrayList<Long>();
 		FloorRequestTimes = new ArrayList<Long>();
+		threadPool = Executors.newFixedThreadPool(SimulationVars.numberOfElevators);
 
 		messenger = new SchedulerMessenger();
 		scheduler = new Scheduler(messenger);

--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -4,6 +4,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
 import java.util.concurrent.*;
+import java.util.ArrayList;
 
 import elevator.Elevator;
 import elevator.ElevatorQueue;
@@ -21,8 +22,15 @@ public class SchedulerSubSystem {
 	private SchedulerMessenger messenger;
 	private Thread faultDetectorThread;
 	private ExecutorService threadPool = Executors.newFixedThreadPool(3);
+	private ArrayList<Long> ElevatorRequestTimes;
+	private ArrayList<Long> FloorArrivalTimes;
+	private ArrayList<Long> FloorRequestTimes;
 
 	public SchedulerSubSystem() {
+		ElevatorRequestTimes = new ArrayList<Long>();
+		FloorArrivalTimes = new ArrayList<Long>();
+		FloorRequestTimes = new ArrayList<Long>();
+
 		messenger = new SchedulerMessenger();
 		scheduler = new Scheduler(messenger);
 
@@ -37,26 +45,32 @@ public class SchedulerSubSystem {
 
 
 		if (m instanceof ElevatorRequestMessage) {
+			Long initTime = System.nanoTime();
 			threadPool.execute(new Runnable() {
 				@Override
 				public void run() {
 					handleElevatorRequest((ElevatorRequestMessage) m);
 				}
 			});
+			ElevatorRequestTimes.add(initTime - System.nanoTime());
 		} else if (m instanceof FloorArrivalMessage) {
+			Long initTime = System.nanoTime();
 			threadPool.execute(new Runnable() {
 				@Override
 				public void run() {
 					handleFloorArrival((FloorArrivalMessage) m);
 				}
 			});
+			FloorArrivalTimes.add(initTime - System.nanoTime());
 		} else if (m instanceof FloorRequestMessage) {
+			Long initTime = System.nanoTime();
 			threadPool.execute(new Runnable() {
 				@Override
 				public void run() {
 					handleFloorRequest((FloorRequestMessage) m);
 				}
 			});
+			FloorRequestTimes.add(initTime - System.nanoTime());
 		}
 	}
 

--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -5,6 +5,8 @@ import java.net.DatagramSocket;
 import java.net.SocketException;
 import java.util.concurrent.*;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import elevator.Elevator;
 import elevator.ElevatorQueue;
@@ -22,14 +24,14 @@ public class SchedulerSubSystem {
 	private SchedulerMessenger messenger;
 	private Thread faultDetectorThread;
 	private ExecutorService threadPool;
-	private ArrayList<Long> ElevatorRequestTimes;
-	private ArrayList<Long> FloorArrivalTimes;
-	private ArrayList<Long> FloorRequestTimes;
+	private List<Long> elevatorRequestTimes;
+	private List<Long> floorArrivalTimes;
+	private List<Long> floorRequestTimes;
 
 	public SchedulerSubSystem() {
-		ElevatorRequestTimes = new ArrayList<Long>();
-		FloorArrivalTimes = new ArrayList<Long>();
-		FloorRequestTimes = new ArrayList<Long>();
+		elevatorRequestTimes = Collections.synchronizedList(new ArrayList<Long>());
+		floorArrivalTimes = Collections.synchronizedList(new ArrayList<Long>());
+		floorRequestTimes = Collections.synchronizedList(new ArrayList<Long>());
 		threadPool = Executors.newFixedThreadPool(SimulationVars.numberOfElevators);
 
 		messenger = new SchedulerMessenger();
@@ -51,27 +53,27 @@ public class SchedulerSubSystem {
 				@Override
 				public void run() {
 					handleElevatorRequest((ElevatorRequestMessage) m);
+					elevatorRequestTimes.add(initTime - System.nanoTime());
 				}
 			});
-			ElevatorRequestTimes.add(initTime - System.nanoTime());
 		} else if (m instanceof FloorArrivalMessage) {
 			Long initTime = System.nanoTime();
 			threadPool.execute(new Runnable() {
 				@Override
 				public void run() {
 					handleFloorArrival((FloorArrivalMessage) m);
+					floorArrivalTimes.add(initTime - System.nanoTime());
 				}
 			});
-			FloorArrivalTimes.add(initTime - System.nanoTime());
 		} else if (m instanceof FloorRequestMessage) {
 			Long initTime = System.nanoTime();
 			threadPool.execute(new Runnable() {
 				@Override
 				public void run() {
 					handleFloorRequest((FloorRequestMessage) m);
+					floorRequestTimes.add(initTime - System.nanoTime());
 				}
 			});
-			FloorRequestTimes.add(initTime - System.nanoTime());
 		}
 	}
 


### PR DESCRIPTION
# What this PR does
Creates a thread pool equal to the number of elevators(each elevator should only be sending one message at a time). The scheduler handles messages in a multithreaded manner.

The amount of times taken to handle `ElevatorRequestMessage`, `FloorArrivalMessage` and `FloorRequestMessage` is recorded but is not used for anything.

# What needs to be done next
Actually use the execution times for analysis etc.