### PR TITLE
Find R&M timings

### DIFF
--- a/src/scheduler/SchedulerMessenger.java
+++ b/src/scheduler/SchedulerMessenger.java
@@ -7,24 +7,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import elevator.Elevator;
-import elevator.ElevatorQueue;
 import elevator.ElevatorShaft;
 import floor.SimulationVars;
 import messages.ElevatorMessage;
 import messages.ElevatorMessage.MessageType;
-import messages.ElevatorRequestMessage;
-import messages.ElevatorRequestMessage.Direction;
 import messages.FloorArrivalMessage;
-import messages.FloorRequestMessage;
 import messages.Message;
 
 public class SchedulerMessenger {
 	private DatagramSocket recvSock, sendSock;
-	private List<Long> mTimes;
+	private List<Long> messageTimes; // list of times in ns to create and send a message
 
 	public SchedulerMessenger() {
-		mTimes = Collections.synchronizedList(new ArrayList<Long>());
+		messageTimes = Collections.synchronizedList(new ArrayList<Long>());
 		try {
 			// Construct a datagram socket and bind it to port 3000
 			// on the local host machine. This socket will be used to
@@ -65,7 +60,7 @@ public class SchedulerMessenger {
 			fm.setDirection(shaft.getQueue().getDirection());
 			sendToFloor(fm);
 		}
-		mTimes.add(System.nanoTime() - start);
+		messageTimes.add(System.nanoTime() - start);
 	}
 
 	public void sendToFloor(FloorArrivalMessage m) {
@@ -87,7 +82,7 @@ public class SchedulerMessenger {
 	}
 
 	public List<Long> getMessageTimes() {
-		return mTimes;
+		return messageTimes;
 	}
 
 	public void close() {

--- a/src/scheduler/SchedulerMessenger.java
+++ b/src/scheduler/SchedulerMessenger.java
@@ -3,6 +3,9 @@ package scheduler;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import elevator.Elevator;
 import elevator.ElevatorQueue;
@@ -18,8 +21,10 @@ import messages.Message;
 
 public class SchedulerMessenger {
 	private DatagramSocket recvSock, sendSock;
+	private List<Long> mTimes;
 
 	public SchedulerMessenger() {
+		mTimes = Collections.synchronizedList(new ArrayList<Long>());
 		try {
 			// Construct a datagram socket and bind it to port 3000
 			// on the local host machine. This socket will be used to
@@ -41,6 +46,7 @@ public class SchedulerMessenger {
 	}
 
 	public void sendToElevator(int currentFloor, int destination, ElevatorShaft shaft) {
+		long start = System.nanoTime();
 		ElevatorMessage m = new ElevatorMessage(directElevatorTo(currentFloor, destination));
 		int id = shaft.getElevator().getId();
 		System.out.println("Scheduler: Sending message of type " + m.getMessageType() + "to Elevator " + id);
@@ -59,6 +65,7 @@ public class SchedulerMessenger {
 			fm.setDirection(shaft.getQueue().getDirection());
 			sendToFloor(fm);
 		}
+		mTimes.add(System.nanoTime() - start);
 	}
 
 	public void sendToFloor(FloorArrivalMessage m) {
@@ -77,6 +84,10 @@ public class SchedulerMessenger {
 			return MessageType.GODOWN;
 		}
 		return MessageType.GOUP;
+	}
+
+	public List<Long> getMessageTimes() {
+		return mTimes;
 	}
 
 	public void close() {

--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -111,15 +111,15 @@ public class SchedulerSubSystem {
 				+ ", Variance: " + sampleVariance(floorArrivalTimes) + " - " + faTimes);
 		System.out.println("Scheduler: Floor Request Response Times (nano) Average: " + average(floorRequestTimes)
 				+ ", Variance: " + sampleVariance(floorRequestTimes) + " - " + frTimes);
-		System.out.println(
-				"Scheduler: Times to send messages (nano) - " + Arrays.toString(messenger.getMessageTimes().toArray()));
-		System.out
-				.println("Scheduler: Average time to send a message (nano) - " + average(messenger.getMessageTimes()));
+		System.out.println("Scheduler: Times to send messages (nano) Average: " + average(messenger.getMessageTimes())
+				+ ", Variance: " + sampleVariance(messenger.getMessageTimes()) + " - "
+				+ Arrays.toString(messenger.getMessageTimes().toArray()));
 		List<Long> tmp = Collections.synchronizedList(new ArrayList<Long>());
 		tmp.addAll(elevatorRequestTimes);
 		tmp.addAll(floorArrivalTimes);
 		tmp.addAll(floorRequestTimes);
-		System.out.println("Scheduler: Average time to run scheduler once (nano) - " + average(tmp));
+		System.out.println("Scheduler: Average time to run scheduler once (nano) Average: " + average(tmp)
+				+ " - Variance: " + sampleVariance(tmp));
 		bExit = true;
 	}
 

--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -1,21 +1,14 @@
 package scheduler;
 
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.SocketException;
-import java.util.concurrent.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
-import elevator.Elevator;
-import elevator.ElevatorQueue;
 import floor.SimulationVars;
-import messages.ElevatorMessage;
-import messages.ElevatorMessage.MessageType;
 import messages.ElevatorRequestMessage;
-import messages.ElevatorRequestMessage.Direction;
 import messages.FloorArrivalMessage;
 import messages.FloorRequestMessage;
 import messages.Message;
@@ -48,7 +41,6 @@ public class SchedulerSubSystem {
 		System.out.println("SchedulerSubSystem: Waiting for message");
 
 		Message m = messenger.receive();
-
 
 		if (m instanceof ElevatorRequestMessage) {
 			Long initTime = System.nanoTime();
@@ -106,15 +98,27 @@ public class SchedulerSubSystem {
 		}
 		scheduler.queueDropOff(m.getElevator(), m.getCurrent(), m.getDestination());
 	}
-	
+
 	private void handleTerminateMessage(TerminateMessage m) {
 		String erTimes = Arrays.toString(elevatorRequestTimes.toArray());
 		String faTimes = Arrays.toString(floorArrivalTimes.toArray());
 		String frTimes = Arrays.toString(floorRequestTimes.toArray());
-		System.out.println("Scheduler: Elevator Request Response Times (nano) - "+ erTimes);
-		System.out.println("Scheduler: Floor Arrival Response Times (nano) - "+ faTimes);
-		System.out.println("Scheduler: Floor Request Response Times (nano) - "+ frTimes);
+		System.out.println("Scheduler: Elevator Request Response Times (nano) - " + erTimes);
+		System.out.println("Scheduler: Floor Arrival Response Times (nano) - " + faTimes);
+		System.out.println("Scheduler: Floor Request Response Times (nano) - " + frTimes);
+		System.out.println(
+				"Scheduler: Times to send messages (nano) - " + Arrays.toString(messenger.getMessageTimes().toArray()));
+		System.out
+				.println("Scheduler: Average time to send a message (nano) - " + average(messenger.getMessageTimes()));
 		bExit = true;
+	}
+
+	private long average(List<Long> times) {
+		long sum = 0;
+		for (Long l : times) {
+			sum += l;
+		}
+		return sum / times.size();
 	}
 
 	public void close() {
@@ -142,7 +146,8 @@ public class SchedulerSubSystem {
 		System.out.println("System exiting...");
 		try {
 			Thread.sleep(3000);
-		} catch (InterruptedException e) {}
+		} catch (InterruptedException e) {
+		}
 		System.exit(0);
 	}
 }

--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -105,9 +105,12 @@ public class SchedulerSubSystem {
 		String erTimes = Arrays.toString(elevatorRequestTimes.toArray());
 		String faTimes = Arrays.toString(floorArrivalTimes.toArray());
 		String frTimes = Arrays.toString(floorRequestTimes.toArray());
-		System.out.println("Scheduler: Elevator Request Response Times (nano) - " + erTimes);
-		System.out.println("Scheduler: Floor Arrival Response Times (nano) - " + faTimes);
-		System.out.println("Scheduler: Floor Request Response Times (nano) - " + frTimes);
+		System.out.println("Scheduler: Elevator Request Response Times (nano) Average: " + average(elevatorRequestTimes)
+				+ ", Variance: " + sampleVariance(elevatorRequestTimes) + " - " + erTimes);
+		System.out.println("Scheduler: Floor Arrival Response Times (nano) Average: " + average(floorArrivalTimes)
+				+ ", Variance: " + sampleVariance(floorArrivalTimes) + " - " + faTimes);
+		System.out.println("Scheduler: Floor Request Response Times (nano) Average: " + average(floorRequestTimes)
+				+ ", Variance: " + sampleVariance(floorRequestTimes) + " - " + frTimes);
 		System.out.println(
 				"Scheduler: Times to send messages (nano) - " + Arrays.toString(messenger.getMessageTimes().toArray()));
 		System.out
@@ -131,6 +134,16 @@ public class SchedulerSubSystem {
 	// this method works... sum times
 	private long average(List<Long> times) {
 		return sum(times) / times.size();
+	}
+
+	private double sampleVariance(List<Long> times) {
+		long mean = average(times);
+		long sum = 0;
+		for (Long l : times) {
+			long xi = l - mean;
+			sum += xi * xi;
+		}
+		return sum / (times.size() - 1);
 	}
 
 	public void close() {

--- a/src/scheduler/SchedulerSubSystem.java
+++ b/src/scheduler/SchedulerSubSystem.java
@@ -22,6 +22,7 @@ public class SchedulerSubSystem {
 	private List<Long> elevatorRequestTimes;
 	private List<Long> floorArrivalTimes;
 	private List<Long> floorRequestTimes;
+	private List<Long> schedulerTimes; // list of times in ns to run scheduler once
 	private boolean bExit = false;
 
 	public SchedulerSubSystem() {
@@ -29,6 +30,7 @@ public class SchedulerSubSystem {
 		floorArrivalTimes = Collections.synchronizedList(new ArrayList<Long>());
 		floorRequestTimes = Collections.synchronizedList(new ArrayList<Long>());
 		threadPool = Executors.newFixedThreadPool(SimulationVars.numberOfElevators);
+		schedulerTimes = Collections.synchronizedList(new ArrayList<Long>());
 
 		messenger = new SchedulerMessenger();
 		scheduler = new Scheduler(messenger);
@@ -110,15 +112,25 @@ public class SchedulerSubSystem {
 				"Scheduler: Times to send messages (nano) - " + Arrays.toString(messenger.getMessageTimes().toArray()));
 		System.out
 				.println("Scheduler: Average time to send a message (nano) - " + average(messenger.getMessageTimes()));
+		List<Long> tmp = Collections.synchronizedList(new ArrayList<Long>());
+		tmp.addAll(elevatorRequestTimes);
+		tmp.addAll(floorArrivalTimes);
+		tmp.addAll(floorRequestTimes);
+		System.out.println("Scheduler: Average time to run scheduler once (nano) - " + average(tmp));
 		bExit = true;
 	}
 
-	private long average(List<Long> times) {
+	private long sum(List<Long> times) {
 		long sum = 0;
 		for (Long l : times) {
 			sum += l;
 		}
-		return sum / times.size();
+		return sum;
+	}
+
+	// this method works... sum times
+	private long average(List<Long> times) {
+		return sum(times) / times.size();
 	}
 
 	public void close() {


### PR DESCRIPTION
This PR stores and logs the `r` and `m` variables in the timing diagram.

### r

The time it takes to run the scheduler algorithm once.
We were already tracking the amount of time it takes for the scheduler to handle the floor arrival, floor request, and elevator request, and each one of these is one iteration of the scheduler's algorithm. So I just found the average of all of these.

values: between `1.04 ms` and `1.76 ms`

### m

The time it takes to create and send one message.
I just found the time it takes to run the `sendToElevator` function

values: between `0.501 ms` and `0.549 ms`